### PR TITLE
Add Chrome new tab extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,13 @@ To install the SOCKS5 proxy server, run the following command:
 
 ```bash
 curl -s -L https://raw.githubusercontent.com/egoistsar/s5proxyserver/main/install.sh | sudo bash
+```
+
+## Chrome Extension
+
+To load the custom new tab extension in Chrome 139 or later:
+
+1. Open `chrome://extensions/` in your browser.
+2. Enable **Developer mode** using the toggle in the top-right corner.
+3. Click **Load unpacked** and select the `chrome_extension` folder from this repository.
+4. A new tab page with advice and a random wallpaper will now appear whenever you open a new tab.

--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "Advice New Tab",
+  "description": "Shows random advice with a wallpaper on each new tab.",
+  "version": "1.0",
+  "manifest_version": 3,
+  "chrome_url_overrides": {
+    "newtab": "newtab.html"
+  },
+  "host_permissions": [
+    "https://api.adviceslip.com/*",
+    "https://source.unsplash.com/*"
+  ]
+}

--- a/chrome_extension/newtab.html
+++ b/chrome_extension/newtab.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>New Tab</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="content">
+    <h1 id="advice">Loading...</h1>
+  </div>
+  <script src="newtab.js"></script>
+</body>
+</html>

--- a/chrome_extension/newtab.js
+++ b/chrome_extension/newtab.js
@@ -1,0 +1,19 @@
+async function loadContent() {
+  const adviceEl = document.getElementById('advice');
+  try {
+    const res = await fetch('https://api.adviceslip.com/advice');
+    const data = await res.json();
+    adviceEl.textContent = data.slip.advice;
+  } catch (e) {
+    adviceEl.textContent = 'Could not load advice.';
+  }
+
+  try {
+    const imgUrl = 'https://source.unsplash.com/random/1920x1080';
+    document.body.style.backgroundImage = `url('${imgUrl}')`;
+  } catch (e) {
+    // ignore image errors
+  }
+}
+
+document.addEventListener('DOMContentLoaded', loadContent);

--- a/chrome_extension/style.css
+++ b/chrome_extension/style.css
@@ -1,0 +1,25 @@
+body {
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-size: cover;
+  background-position: center;
+  font-family: Arial, sans-serif;
+}
+
+#content {
+  background: rgba(0,0,0,0.5);
+  color: #fff;
+  padding: 1rem 2rem;
+  border-radius: 8px;
+  max-width: 90%;
+  text-align: center;
+}
+
+@media (max-width: 600px) {
+  #content {
+    padding: 0.5rem 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- create a `chrome_extension` folder with manifest, HTML, CSS and JS
- display advice text and random wallpaper on each new tab
- document how to load the extension in Chrome

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6883446492308330865de458613fd15d